### PR TITLE
Convert some endpoints from POST to GET.

### DIFF
--- a/backend/src/gdc/gdc.ts
+++ b/backend/src/gdc/gdc.ts
@@ -88,9 +88,8 @@ export const computeGDC = (
     const isVariant = hist.dataseries !== undefined;
     const displayKPI = hist.kpi + (isVariant ? ` - ${hist.dataseries}` : '');
 
-    let score: IndicatorScore | IndicatorWithoutGoal | undefined = outputIndicatorScores.get(
-      displayKPI,
-    );
+    let score: IndicatorScore | IndicatorWithoutGoal | undefined =
+      outputIndicatorScores.get(displayKPI);
     if (score === undefined) {
       // Did not get score from indicators with goals, try the ones without goals instead...
       score = indicatorsWithoutGoals.get(displayKPI);

--- a/backend/src/routes/data.ts
+++ b/backend/src/routes/data.ts
@@ -96,7 +96,10 @@ const insertBulkData = async (req: Request, res: Response) => {
 
 const getData = async (req: Request, res: Response) => {
   try {
-    const data = await getDataSeries(req.body.indicator, req.body.municipality, req.body.year);
+    const year = parseInt(req.params.year, 10);
+    if (Number.isNaN(year)) throw new ApiError(400, 'Non-integer year');
+
+    const data = await getDataSeries(req.params.indicator, req.params.municipality, year);
     res.json(data);
   } catch (e: any) {
     onError(e, req, res);
@@ -110,7 +113,7 @@ const getData = async (req: Request, res: Response) => {
  */
 const getAllData = async (req: Request, res: Response) => {
   try {
-    let data = await getDataSeriesForMunicipality(req.body.municipality);
+    let data = await getDataSeriesForMunicipality(req.params.municipality);
 
     // Group by kpiNumber and then potentially dataseriesVariant
     // Also removes all properties but value and year from the datapoints themselves
@@ -242,8 +245,8 @@ const dataUploadCSV = async (req: Request, res: Response) => {
 
 router.post('/insert', verifyDatabaseAccess, verifyToken, insertData);
 router.post('/insert-bulk', verifyDatabaseAccess, verifyToken, insertBulkData);
-router.post('/get', verifyDatabaseAccess, getData);
-router.post('/get-all-dataseries', verifyDatabaseAccess, getAllData);
+router.get('/get/:municipality/:year/:indicator', verifyDatabaseAccess, getData);
+router.get('/get-all-dataseries/:municipality', verifyDatabaseAccess, getAllData);
 
 router.get('/available-years/:municipality', verifyDatabaseAccess, availableYears);
 

--- a/backend/src/tests/integration.spec.ts
+++ b/backend/src/tests/integration.spec.ts
@@ -90,11 +90,10 @@ describe('Insertion test with valid values', () => {
     expect(response.status).equal(200);
   });
   it('returns the inserted values', async () => {
-    const response = await agent.post('/api/data/get').send({
-      indicator: 'EC: ICT: ICT: 1C',
-      municipality: 'no.5001',
-      year: 2020,
-    });
+    const indicator = 'EC: ICT: ICT: 1C';
+    const municipality = 'no.5001';
+    const year = 2020;
+    const response = await agent.get(`/api/data/get/${municipality}/${year}/${indicator}`);
 
     expect(response.status).equal(200);
     expect(response.body).not.eq({});

--- a/frontend/src/api/gdc.ts
+++ b/frontend/src/api/gdc.ts
@@ -14,11 +14,16 @@ export const getGDCOutput = async (
   overrideMode?: string,
 ): Promise<GDCOutput> => {
   try {
-    const reqBody =
-      goalOverride !== undefined
-        ? { municipality, year, goalOverride, overrideMode }
-        : { municipality, year };
-    return await api.POST('gdc/get', reqBody).then((data) => {
+    let path = `gdc/compute/${municipality}/${year}`;
+    if (goalOverride) {
+      path = `${path}/${goalOverride}`;
+    }
+
+    if (overrideMode) {
+      path = `${path}/${overrideMode}`;
+    }
+
+    return await api.GET(path).then((data) => {
       try {
         const domains: Map<string, Score> = new Map<string, Score>(data.domains);
         const subdomains: Map<string, Score> = new Map<string, Score>(data.subdomains);


### PR DESCRIPTION
## Proposed changes
- Renames gdc computation endpoint from `/gdc/get` to `/gdc/compute`
- Changes `/gdc/compute` to GET
- Changes `/data/get` to GET
- Changes `/data/get-all-dataseries` to GET
- Applies formatting rules

## Additional info
- Took the liberty to rename the GDC computation endpoint to something more suitable

## How has this been tested?
- [x] Test have been ran
- [x] Manually tested